### PR TITLE
fixed weighted versions of the analysis

### DIFF
--- a/R/statistic-mean.R
+++ b/R/statistic-mean.R
@@ -82,6 +82,9 @@ run_mean <- function(mat,
             to_sparse = sparse,
             values_fill = 0
         )
+    
+    # This fixes the wrong denominator defined in contribution
+    weight_mat <- t(t(weight_mat)/colSums(abs(weight_mat)))
 
     # Analysis ----------------------------------------------------------------
     withr::with_seed(seed, {
@@ -172,7 +175,7 @@ run_mean <- function(mat,
         transmute(
             .data$tf,
             .data$target,
-            weight = .data$mor * .data$likelihood / .data$contribution
+            weight = .data$mor * .data$likelihood
         )
 }
 

--- a/R/utils-dataset-converters.R
+++ b/R/utils-dataset-converters.R
@@ -54,7 +54,7 @@ convert_to_ <- function(network) invisible(network)
 #'
 #' @family convert_to_ variants
 #' @export
-convert_to_scira <- function(network, .source, .target, .mor = NULL) {
+convert_to_scira <- function(network, .source, .target, .mor = NULL, .likelihood = NULL) {
     .check_quos_status({{ .source }}, {{ .target }},
         .dots_names = c(".source", ".target")
     )
@@ -64,7 +64,8 @@ convert_to_scira <- function(network, .source, .target, .mor = NULL) {
             tf = {{ .source }},
             target = {{ .target }},
             mor = {{ .mor }},
-            .def_col_val = c(mor = 0)
+            likelihood = {{ .likelihood }},
+            .def_col_val = c(mor = 0, likelihood = 1)
         ) %>%
         mutate(mor = sign(.data$mor))
 }
@@ -75,7 +76,7 @@ convert_to_scira <- function(network, .source, .target, .mor = NULL) {
 #'
 #' @family convert_to_ variants
 #' @export
-convert_to_pscira <- function(network, .source, .target, .mor = NULL) {
+convert_to_pscira <- function(network, .source, .target, .mor = NULL, .likelihood = NULL) {
     .check_quos_status({{ .source }}, {{ .target }},
         .dots_names = c(".source", ".target")
     )
@@ -85,7 +86,8 @@ convert_to_pscira <- function(network, .source, .target, .mor = NULL) {
             tf = {{ .source }},
             target = {{ .target }},
             mor = {{ .mor }},
-            .def_col_val = c(mor = 0)
+            likelihood = {{ .likelihood }},
+            .def_col_val = c(mor = 0, likelihood = 1)
         ) %>%
         mutate(mor = sign(.data$mor))
 }


### PR DESCRIPTION
-SCIRA and PSCIRA methods now ask for likelihood parameter.
-SCIRA and PSCIRA provide to the analysis a weighted matrix that is a point matrix multiplication between mor and likelihood matrices
-PSCIRA returns 2 statistics, pscira coming from the multiplication) and normalized_pscira, that comes from the permutation analysis 
-MEAN method now includes a fixed weighted matrix that uses as denominator the absolute sum of mor * likelihood, as it is supposed to work
-dataset cone